### PR TITLE
Fix for flashlight not turning back on

### DIFF
--- a/Assets/SpectrumTesting.unity
+++ b/Assets/SpectrumTesting.unity
@@ -328,6 +328,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 08e828fbbb29a4545ab4cd49c1423046, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  lightIntensity: 2
 --- !u!1 &635937813
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
I'm not sure if I forgot to set that variable in the inspector or if I committed it after experimenting with setting it to zero, but it has been fixed.  My bad, I obviously didn't test it well enough before I opened the pull request.

The issue was that the variable was being set by the editor to 0.  So when you hit 'q' the script logic would set intensity to 0.  Then when you hit 'q' again the script logic see's that the intensity is set to 0, so it sets it to the variable that's passed in, which was zero.  Now it will set it to 2 (or whatever intensity we decide is appropriate).  I imagine there will be times when we will want external access so that a monster could turn off the light, or maybe a certain room could trigger it turning on and off.
